### PR TITLE
Add banned nicknames list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, you must enable console logging, to achieve this you can do one of the fo
 
 If you used the latter option your path probably looks something like this: ``C:\Program Files\SteamLibrary\steamapps\common\Counter-Strike Global Offensive\game\csgo\console.log``
 
-+ Open `config.ini` and set `gameconlogpath` to the appropriate path, there you will also set your in-game username and your OpenRouter API key.
++ Open `config.ini` и укажи путь в `gameconlogpath`. В поле `bannednicks` перечисли ники через запятую, которые бот должен игнорировать, и введи свой OpenRouter API ключ.
 
 Now you can do `python chat.py`
 

--- a/chat.py
+++ b/chat.py
@@ -34,7 +34,7 @@ def set_status(sender, app_data, user_data):
 
 
 def save_config():
-    cp.config['SETTINGS']['username'] = dpg.get_value("username")
+    cp.config['SETTINGS']['bannednicks'] = dpg.get_value("banned_nicks")
     cp.config['SETTINGS']['gameconlogpath'] = dpg.get_value("conlog")
     cp.config['SETTINGS']['chatkey'] = dpg.get_value("chat_keybind")
     with open(cp.CONFIG_FILE, 'w') as configfile:
@@ -74,7 +74,9 @@ def main():
     with dpg.window(label="Chat-Strike", width=600, height=300, tag="Chat-Strike"):
         dpg.add_text(f"Detected game: {game}")
         
-        dpg.add_input_text(hint="Blacklisted username", default_value=cp.BLACKLISTED_USERNAME, tag="username")
+        dpg.add_input_text(hint="Banned nicknames (comma separated)",
+                           default_value=','.join(cp.BANNED_NICKS),
+                           tag="banned_nicks")
         dpg.add_input_text(hint=".log file path", default_value=cp.CON_LOG_FILE_PATH, tag="conlog")
         dpg.add_input_text(hint="OpenRouter key", default_value=openai.api_key, password=True, tag="openapi_key")
         dpg.add_input_text(hint="Chat keybind", default_value=cp.CHAT_KEY, tag="chat_keybind")
@@ -118,7 +120,7 @@ def main():
                     #print(f"[DEBUG] {username}: {message}:")
                     # This way we prevent chat-gpt from talking to itself
                     logger.debug("Username: %s", username)
-                    if cp.BLACKLISTED_USERNAME != username:
+                    if username not in cp.BANNED_NICKS:
                         cp.sim_key_presses(openrouter_interact(username, message))
                     else:
                         logger.debug("Message ignored from blacklisted user")

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,6 @@
 [SETTINGS]
 username=test1
-gameconlogpath=C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\console.log
+gameconlogpath=C:\\Program Files (x86)\\Steam\\steamapps\\common\\Counter-Strike Global Offensive\\game\\csgo\\console.log
 openrouterapikey=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
 chatkey=y
+bannednicks=test1

--- a/conparser.py
+++ b/conparser.py
@@ -11,7 +11,8 @@ CONFIG_FILE = 'config.ini'
 
 config.read(CONFIG_FILE, encoding='utf-8')
 
-BLACKLISTED_USERNAME = config['SETTINGS']['username']
+# List of nicknames to ignore, comma separated in config
+BANNED_NICKS = [n.strip() for n in config['SETTINGS'].get('bannednicks', '').split(',') if n.strip()]
 CON_LOG_FILE_PATH = config['SETTINGS']['gameconlogpath']
 CHAT_KEY = config['SETTINGS']['chatkey']
 


### PR DESCRIPTION
## Summary
- allow specifying banned nicknames list in `config.ini`
- support ignoring multiple names in `conparser.py`
- update GUI and logic in `chat.py`
- document `bannednicks` in README

## Testing
- `flake8 .` *(fails: E302, E712, E501, W293, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6877d4aabb0883329ffbd16b1449354b