### PR TITLE
Add support for multiple blacklisted usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First, you must enable console logging, to achieve this you can do one of the fo
 
 If you used the latter option your path probably looks something like this: ``C:\Program Files\SteamLibrary\steamapps\common\Counter-Strike Global Offensive\game\csgo\console.log``
 
-+ Open `config.ini` and set `gameconlogpath` to the appropriate path, there you will also set your in-game username and your OpenRouter API key.
++ Open `config.ini` and set `gameconlogpath` to the appropriate path. Здесь же можно указать список ников в `blacklisted_usernames` (через запятую) и свой OpenRouter API ключ.
 
 Now you can do `python chat.py`
 

--- a/chat.py
+++ b/chat.py
@@ -29,7 +29,7 @@ def set_status(sender, app_data, user_data):
 
 
 def save_config():
-    cp.config['SETTINGS']['username'] = dpg.get_value("username")
+    cp.config['SETTINGS']['blacklisted_usernames'] = dpg.get_value("usernames")
     cp.config['SETTINGS']['gameconlogpath'] = dpg.get_value("conlog")
     cp.config['SETTINGS']['chatkey'] = dpg.get_value("chat_keybind")
     with open(cp.CONFIG_FILE, 'w') as configfile:
@@ -85,7 +85,9 @@ def main():
     with dpg.window(label="Chat-Strike", width=600, height=300, tag="Chat-Strike"):
         dpg.add_text(f"Detected game: {game}")
         
-        dpg.add_input_text(hint="Blacklisted username", default_value=cp.BLACKLISTED_USERNAME, tag="username")
+        dpg.add_input_text(hint="Blacklisted usernames (comma separated)",
+                           default_value=','.join(cp.BLACKLISTED_USERNAMES),
+                           tag="usernames")
         dpg.add_input_text(hint=".log file path", default_value=cp.CON_LOG_FILE_PATH, tag="conlog")
         dpg.add_input_text(hint="OpenRouter key", default_value=OPENROUTER_API_KEY, password=True, tag="openapi_key")
         dpg.add_input_text(hint="Chat keybind", default_value=cp.CHAT_KEY, tag="chat_keybind")
@@ -129,7 +131,7 @@ def main():
                     #print(f"[DEBUG] {username}: {message}:")
                     # This way we prevent chat-gpt from talking to itself
                     logger.debug("Username: %s", username)
-                    if cp.BLACKLISTED_USERNAME != username:
+                    if username not in cp.BLACKLISTED_USERNAMES:
                         cp.sim_key_presses(openrouter_interact(username, message))
                     else:
                         logger.debug("Message ignored from blacklisted user")

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 [SETTINGS]
-username=test1
+blacklisted_usernames=test1
 gameconlogpath=C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\console.log
 openrouterapikey=
 chatkey=y

--- a/conparser.py
+++ b/conparser.py
@@ -11,7 +11,7 @@ CONFIG_FILE = 'config.ini'
 
 config.read(CONFIG_FILE, encoding='utf-8')
 
-BLACKLISTED_USERNAME = config['SETTINGS']['username']
+BLACKLISTED_USERNAMES = [name.strip() for name in config['SETTINGS'].get('blacklisted_usernames', '').split(',') if name.strip()]
 CON_LOG_FILE_PATH = config['SETTINGS']['gameconlogpath']
 CHAT_KEY = config['SETTINGS']['chatkey']
 

--- a/fix.patch
+++ b/fix.patch
@@ -42,7 +42,7 @@ index 0b1cb55bddb610fadc4993800883d4cee895df22..2b5b5a60a234b7cced14833b084a29d8
  
  
  def save_config():
-     cp.config['SETTINGS']['username'] = dpg.get_value("username")
+     cp.config['SETTINGS']['blacklisted_usernames'] = dpg.get_value("usernames")
      cp.config['SETTINGS']['gameconlogpath'] = dpg.get_value("conlog")
      cp.config['SETTINGS']['chatkey'] = dpg.get_value("chat_keybind")
      with open(cp.CONFIG_FILE, 'w') as configfile:
@@ -101,7 +101,7 @@ index 0b1cb55bddb610fadc4993800883d4cee895df22..2b5b5a60a234b7cced14833b084a29d8
      with dpg.window(label="Chat-Strike", width=600, height=300, tag="Chat-Strike"):
          dpg.add_text(f"Detected game: {game}")
          
-         dpg.add_input_text(hint="Blacklisted username", default_value=cp.BLACKLISTED_USERNAME, tag="username")
+         dpg.add_input_text(hint="Blacklisted usernames (comma separated)", default_value=','.join(cp.BLACKLISTED_USERNAMES), tag="usernames")
          dpg.add_input_text(hint=".log file path", default_value=cp.CON_LOG_FILE_PATH, tag="conlog")
 -        dpg.add_input_text(hint="OpenRouter key", default_value=openai.api_key, password=True, tag="openapi_key")
 +        dpg.add_input_text(hint="OpenRouter key", default_value=OPENROUTER_API_KEY, password=True, tag="openapi_key")


### PR DESCRIPTION
## Summary
- allow comma-separated usernames via `blacklisted_usernames` config field
- adapt UI and saving logic to handle multiple usernames
- ignore messages from all blacklisted names
- document new setting in README

## Testing
- `python -m py_compile chat.py conparser.py`


------
https://chatgpt.com/codex/tasks/task_e_6877d66f20ac83329c2524bb2f47afbf