### PR TITLE
Обработка командного чата

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -146,7 +146,7 @@ def main():
                 if not line:
                     continue
                 logger.debug(line.strip())
-                username, message = cp.parse_log(game, line)
+                username, message, chat_type = cp.parse_log(game, line)
 
                 if username and message:
                     #print(f"[DEBUG] {username}: {message}:")
@@ -155,7 +155,8 @@ def main():
                     if username not in cp.BLACKLISTED_USERNAMES:
                         reply = openrouter_interact(username, message)
                         if reply:
-                            cp.sim_key_presses(reply)
+                            key = cp.TEAM_CHAT_KEY if chat_type == "team" else cp.CHAT_KEY
+                            cp.sim_key_presses(reply, key)
                         else:
                             logger.debug("Empty reply, skipping keystrokes")
                     else:

--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,4 @@ blacklisted_usernames=Mecripas
 gameconlogpath=C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\console.log
 openrouterapikey=
 chatkey=y
+teamchatkey=u


### PR DESCRIPTION
## Summary
- добавил настройку `teamchatkey` в конфиг
- определяем тип сообщения (общий/командный)
- отправка ответа идёт в тот же чат, откуда пришло сообщение

## Testing
- `python -m py_compile chat.py conparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6879015c08d8833299ab27a396304979