### PR TITLE
Add debug console to Chat-Strike UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you used the latter option your path probably looks something like this: ``C:
 
 + Open `config.ini` and set `gameconlogpath` to the appropriate path. Здесь же можно указать список ников в `blacklisted_usernames` (через запятую) и свой OpenRouter API ключ.
 
-Now you can do `python chat.py`
+Now you can do `python chat.py`. В интерфейсе появилась отладочная консоль, куда дублируются ваши сообщения и ответы бота.
 
 The system prompt for ChatGPT is stored in `system_prompt.txt`. Вы можете
 отредактировать этот файл, чтобы изменить поведение бота.


### PR DESCRIPTION
## Summary
- add a debug console window in `chat.py`
- log chat messages and OpenRouter replies to the console
- note the new debug console in `README`

## Testing
- `python -m py_compile chat.py conparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6879054bd21083328564470e4703aec0