### PR TITLE
Fix Cyrillic display and console overlap

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -1,5 +1,7 @@
 import requests
 import logging
+import os
+import sys
 
 import dearpygui.dearpygui as dpg
 import conparser as cp
@@ -29,8 +31,8 @@ class Status():
 def debug_log(text: str):
     if dpg.does_item_exist("debug_console"):
         current = dpg.get_value("debug_console")
-        dpg.set_value("debug_console", f"{current}{text}\n")
-        dpg.set_y_scroll("Debug Console", dpg.get_y_scroll_max("Debug Console"))
+        dpg.set_value("debug_console", f"{text}\n{current}")
+        dpg.set_y_scroll("Debug Console", 0)
 
 
 def set_status(sender, app_data, user_data):
@@ -106,6 +108,17 @@ def main():
     dpg.create_context()
     dpg.create_viewport(title='Chat-Strike', width=600, height=500)
 
+    if sys.platform.startswith('win'):
+        # Попробуем подобрать стандартный моноширинный шрифт с поддержкой кириллицы
+        win_dir = os.environ.get('WINDIR', 'C:\\Windows')
+        for fname in ("consola.ttf", "lucon.ttf", "cour.ttf"):
+            font_path = os.path.join(win_dir, "Fonts", fname)
+            if os.path.exists(font_path):
+                with dpg.font_registry():
+                    default_font = dpg.add_font(font_path, 14)
+                    dpg.bind_font(default_font)
+                break
+
     with dpg.window(label="Chat-Strike", width=600, height=180, tag="Chat-Strike"):
         dpg.add_text(f"Detected game: {game}")
         
@@ -122,7 +135,7 @@ def main():
         dpg.add_button(label="Start", callback=set_status, user_data=status_text, tag="start_button")
 
     with dpg.window(label="Debug Console", width=600, height=300, pos=(0,200), tag="Debug Console"):
-        dpg.add_input_text(tag="debug_console", multiline=True, readonly=True, width=-1, height=-1)
+        dpg.add_input_text(tag="debug_console", multiline=True, readonly=True, width=-1, height=280)
 
 
 


### PR DESCRIPTION
## Summary
- search for common Windows fonts with Cyrillic support and use a smaller size
- set console height and scroll to newest message at the top

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68791b54d5248332aeb56c6481ccbd61