### PR TITLE
Fix blacklist check for dead players

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ with open(cp.CON_LOG_FILE_PATH, encoding=cp.CON_LOG_ENCODING) as logfile:
             line = cp.rt_file_read(logfile)
             if not line:
                 continue
-            print(cp.parse_log(game, line)) # [username, message, chat_type, prefix]
+            print(cp.parse_log(game, line))  # ParsedLog(username, message, chat_type, prefix, is_dead)
 ```
 
 

--- a/chat.py
+++ b/chat.py
@@ -180,14 +180,23 @@ def main():
                 if not line:
                     continue
                 logger.debug(line.strip())
-                username, message, chat_type, prefix = cp.parse_log(game, line)
+                parsed = cp.parse_log(game, line)
+                if parsed is None:
+                    continue
+                username = parsed.username
+                message = parsed.message
+                chat_type = parsed.chat_type
+                prefix = parsed.prefix
+                display_name = (
+                    f"{username} [МЕРТВ]" if parsed.is_dead else username
+                )
 
                 if username and message:
                     #print(f"[DEBUG] {username}: {message}:")
                     # This way we prevent chat-gpt from talking to itself
                     logger.debug("Username: %s", username)
                     if username not in cp.BLACKLISTED_USERNAMES:
-                        reply = openrouter_interact(username, message, prefix)
+                        reply = openrouter_interact(display_name, message, prefix)
                         if reply:
                             if reply.strip() == "[IGNORE]":
                                 logger.debug("[IGNORE] received, skipping keystrokes")


### PR DESCRIPTION
## Summary
- represent parsed log entries with a `ParsedLog` dataclass
- return the new dataclass from `parse_log`
- handle `is_dead` flag in `chat.py` and keep usernames intact for blacklist check
- update README example

## Testing
- `pip install -r requirements.txt`
- `pip install flake8`
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_687942248bc883329b56d26d53346674