### PR TITLE
Fix username sanitization for blacklist in team chat

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -188,9 +188,7 @@ def main():
                 message = parsed.message
                 chat_type = parsed.chat_type
                 prefix = parsed.prefix
-                display_name = (
-                    username
-                )
+                display_name = cp.sanitize_username(username)
                 debug_log(display_name)
                 debug_log(prefix)
 
@@ -198,8 +196,11 @@ def main():
                     #print(f"[DEBUG] {username}: {message}:")
                     # This way we prevent chat-gpt from talking to itself
                     logger.debug("Username: %s", username)
-                    checked_username = username.replace(' [МЁРТВ]', '').strip()
-                    if (checked_username not in cp.BLACKLISTED_USERNAMES) or ("[test]" in message):
+                    checked_username = cp.sanitize_username(username).lower()
+                    blacklisted = any(
+                        checked_username == b.lower() for b in cp.BLACKLISTED_USERNAMES
+                    )
+                    if (not blacklisted) or ("[test]" in message):
                         reply = openrouter_interact(display_name, message, prefix)
                         if reply:
                             if reply.strip() == "[IGNORE]":

--- a/conparser.py
+++ b/conparser.py
@@ -30,6 +30,18 @@ class ParsedLog:
     is_dead: bool = False
 
 
+def sanitize_username(name: str) -> str:
+    """Strip location markers and death tags from username."""
+    if not name:
+        return ""
+    name = name.replace(" [МЁРТВ]", "")
+    for sep in ("@", "﹫"):
+        if sep in name:
+            name = name.split(sep, 1)[0]
+            break
+    return name.strip()
+
+
 def detect_game(custom_proc="customproc"):
     pname = None
     for proc in psutil.process_iter():


### PR DESCRIPTION
## Summary
- add helper `sanitize_username` to strip location markers
- use sanitized username in chat flow

## Testing
- `python -m py_compile chat.py conparser.py`


------
https://chatgpt.com/codex/tasks/task_e_687d67926a348332bb2e0dea3e87596e