### PR TITLE
Improve chat pasting to avoid stuck key input

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ with open(cp.CON_LOG_FILE_PATH, encoding=cp.CON_LOG_ENCODING) as logfile:
 ## How it works
 
 Very similar to Isaac's framework this script reads the console log file. New entries are parsed and sent to chat-gpt to generate a response which is then sent back in game chat through simulated keystrokes.
+Now the bot pastes messages from the clipboard to avoid stray characters when movement keys are held.
 
 If messages do not appear in game, try running the script with administrator rights. Some games ignore simulated key presses without the proper permissions.
 If the LLM replies with `[IGNORE]`, nothing will be sent to the in-game chat.

--- a/conparser.py
+++ b/conparser.py
@@ -1,6 +1,7 @@
 import time
 import configparser
 import keyboard
+import pyperclip
 import psutil
 import logging
 from dataclasses import dataclass
@@ -156,16 +157,22 @@ def rt_file_read(file: __file__):
 
 
 def sim_key_presses(text: str, key: str = CHAT_KEY):
-    """Send a chat message using several input methods."""
+    """Send a chat message using clipboard paste to avoid stray key presses."""
     keyboard.press_and_release(key)
     time.sleep(0.05)
-    try:
-        keyboard.write(text)
-    except Exception as exc:
-        logger.debug("keyboard.write failed: %s, falling back to win32", exc)
-        _win32_write(text)
+
+    prev_clip = pyperclip.paste()
+    pyperclip.copy(text)
+
+    # replace any accidental input (e.g. held movement keys)
+    keyboard.press_and_release('ctrl+a')
+    time.sleep(0.01)
+    keyboard.press_and_release('ctrl+v')
     time.sleep(0.05)
     keyboard.press_and_release('enter')
+
+    # restore previous clipboard contents
+    pyperclip.copy(prev_clip)
 
 
 def _win32_write(text: str):


### PR DESCRIPTION
## Summary
- switch to clipboard-based input to prevent extra keys while walking
- document clipboard approach in README

## Testing
- `python -m py_compile chat.py conparser.py`


------
https://chatgpt.com/codex/tasks/task_e_687ed05446908332bbaa2e66ecf1c6ca