### PR TITLE
Add quick bind prompt feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,17 @@ Now the bot pastes messages from the clipboard to avoid stray characters when mo
 
 If messages do not appear in game, try running the script with administrator rights. Some games ignore simulated key presses without the proper permissions.
 If the LLM replies with `[IGNORE]`, nothing will be sent to the in-game chat.
+
+## Bind prompts
+
+В папке `bind_prompts` лежат файлы `bind1.txt` – `bind10.txt`.
+В каждом напишите системный промпт для быстрого сообщения.
+В игре можно создать бинды так:
+
+```
+bind "f3" "echo [bind1 team]"
+bind "f4" "echo [bind2]"
+```
+
+`team` или `all` после названия задаёт тип чата. При нажатии клавиши бот
+отправит сгенерированный текст в выбранный чат без учёта истории.

--- a/bind_prompts/bind1.txt
+++ b/bind_prompts/bind1.txt
@@ -1,0 +1,1 @@
+Prompt for bind 1

--- a/bind_prompts/bind10.txt
+++ b/bind_prompts/bind10.txt
@@ -1,0 +1,1 @@
+Prompt for bind 10

--- a/bind_prompts/bind2.txt
+++ b/bind_prompts/bind2.txt
@@ -1,0 +1,1 @@
+Prompt for bind 2

--- a/bind_prompts/bind3.txt
+++ b/bind_prompts/bind3.txt
@@ -1,0 +1,1 @@
+Prompt for bind 3

--- a/bind_prompts/bind4.txt
+++ b/bind_prompts/bind4.txt
@@ -1,0 +1,1 @@
+Prompt for bind 4

--- a/bind_prompts/bind5.txt
+++ b/bind_prompts/bind5.txt
@@ -1,0 +1,1 @@
+Prompt for bind 5

--- a/bind_prompts/bind6.txt
+++ b/bind_prompts/bind6.txt
@@ -1,0 +1,1 @@
+Prompt for bind 6

--- a/bind_prompts/bind7.txt
+++ b/bind_prompts/bind7.txt
@@ -1,0 +1,1 @@
+Prompt for bind 7

--- a/bind_prompts/bind8.txt
+++ b/bind_prompts/bind8.txt
@@ -1,0 +1,1 @@
+Prompt for bind 8

--- a/bind_prompts/bind9.txt
+++ b/bind_prompts/bind9.txt
@@ -1,0 +1,1 @@
+Prompt for bind 9


### PR DESCRIPTION
## Summary
- support special console commands `[bindN]` for quick prompts
- load 10 prompt files from `bind_prompts` directory
- send quick prompts without history using new `openrouter_quick_prompt()`
- document bind usage in README

## Testing
- `pip install -r requirements.txt`
- `flake8 .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687fb8c6d180833299fb0de03560c26d